### PR TITLE
Removes default values for Faraday’s SSL settings `ca_file` and `ca_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
-### 0.2.1 (Next)
+### 0.3.0 (Next)
 
+* Removes default values for Faraday’s SSL settings `ca_file` and `ca_path`.
+
+    If you previously relied on `OpenSSL::X509::DEFAULT_CERT_FILE` or `OpenSSL::X509::DEFAULT_CERT_DIR` to set these values you must now do so explicitly. E.g.:
+
+    ```ruby
+    OpenWeather::Client.configure do |config|
+      config.ca_path = OpenSSL::X509::DEFAULT_CERT_DIR
+      config.ca_file = OpenSSL::X509::DEFAULT_CERT_FILE
+    end
+    ```
 * [#21](https://github.com/dblock/open-weather-ruby-client/pull/21), [#20](https://github.com/dblock/open-weather-ruby-client/pull/20), [#19](https://github.com/dblock/open-weather-ruby-client/pull/19), [#18](https://github.com/dblock/open-weather-ruby-client/pull/18): Added support for Stations API - [@wasabigeek](https://github.com/wasabigeek).
 * [#22](https://github.com/dblock/open-weather-ruby-client/pull/23): Removed API version from `Config#endpoint` - [@dblock](https://github.com/dblock).
 * Your contribution here.

--- a/lib/open_weather/config.rb
+++ b/lib/open_weather/config.rb
@@ -24,8 +24,8 @@ module OpenWeather
       self.endpoint = 'https://api.openweathermap.org/data'
       self.api_key = nil
       self.user_agent = "OpenWeather Ruby Client/#{OpenWeather::VERSION}"
-      self.ca_path = defined?(OpenSSL) ? OpenSSL::X509::DEFAULT_CERT_DIR : nil
-      self.ca_file = defined?(OpenSSL) ? OpenSSL::X509::DEFAULT_CERT_FILE : nil
+      self.ca_path = nil
+      self.ca_file = nil
       self.proxy = nil
       self.logger = nil
       self.timeout = nil

--- a/lib/open_weather/version.rb
+++ b/lib/open_weather/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenWeather
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
Closes #26