### PR TITLE
Add support for base plan one_call API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-### 0.5.1 (Next)
+### 0.6.0 (Next)
 
 * [#40](https://github.com/dblock/open-weather-ruby-client/pull/40): Fixing rubocop violations and improved .rubocop.yml - [@troya2](https://github.com/troya2).
 * [#41](https://github.com/dblock/open-weather-ruby-client/pull/41): Added additional tests for hourly forecast that include all data types - i.e. rain and snow - [@troya2](https://github.com/troya2).
 * [#42](https://github.com/dblock/open-weather-ruby-client/pull/42): Added support for the thirty day forecast in the pro 2.5 API - [@troya2](https://github.com/troya2).
+* [#45](https://github.com/dblock/open-weather-ruby-client/pull/45): Added support for One Call 3.0 API on base plan - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.5.0 (2024/07/03)

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ data.lat # => 33.44
 data.lon # => -94.04
 data.timezone # => 'America/Chicago'
 data.current # => OpenWeather::Models::OneCall::CurrentWeather
+data.data # => Array]OpenWeather::Models::OneCall::CurrentWeather] (on base plan)
 data.minutely # => Array[OpenWeather::Models::OneCall::MinutelyWeather]
 data.hourly # => Array[OpenWeather::Models::OneCall::HourlyWeather]
 data.daily # => Array[OpenWeather::Models::OneCall::DailyWeather]
@@ -368,19 +369,19 @@ end
 
 The following settings are supported.
 
-setting             | description
---------------------|------------
-api_key             | Required API key.
-lang                | Default language in API responses.
-units               | Default units in API responses.
-endpoint            | Defaults to `https://api.openweathermap.org/data`.
-user_agent          | User-agent, defaults to _OpenWeather Ruby Client/version_.
-proxy               | Optional HTTP proxy.
-ca_path             | Optional SSL certificates path.
-ca_file             | Optional SSL certificates file.
-logger              | Optional `Logger` instance that logs HTTP requests.
-timeout             | Optional open/read timeout in seconds.
-open_timeout        | Optional connection open timeout in seconds.
+| setting      | description                                                |
+| ------------ | ---------------------------------------------------------- |
+| api_key      | Required API key.                                          |
+| lang         | Default language in API responses.                         |
+| units        | Default units in API responses.                            |
+| endpoint     | Defaults to `https://api.openweathermap.org/data`.         |
+| user_agent   | User-agent, defaults to _OpenWeather Ruby Client/version_. |
+| proxy        | Optional HTTP proxy.                                       |
+| ca_path      | Optional SSL certificates path.                            |
+| ca_file      | Optional SSL certificates file.                            |
+| logger       | Optional `Logger` instance that logs HTTP requests.        |
+| timeout      | Optional open/read timeout in seconds.                     |
+| open_timeout | Optional connection open timeout in seconds.               |
 
 ### Units
 

--- a/lib/open_weather/models/one_call/weather.rb
+++ b/lib/open_weather/models/one_call/weather.rb
@@ -12,11 +12,13 @@ module OpenWeather
         property 'hourly' # hourly forecast weather
         property 'daily' # daily forecast weather
         property 'alerts' # weather alerts for the location
+        property 'data' # weather data
 
         def initialize(args = nil, options = {})
           super args, options
 
           self.current = OpenWeather::Models::OneCall::CurrentWeather.new(current, options) if current
+          self.data = data.map { |i| OpenWeather::Models::OneCall::CurrentWeather.new(i, options) } if data
           self.minutely = minutely.map { |i| OpenWeather::Models::OneCall::MinutelyWeather.new(i, options) } if minutely
           self.hourly = hourly.map { |i| OpenWeather::Models::OneCall::HourlyWeather.new(i, options) } if hourly
           self.daily = daily.map { |i| OpenWeather::Models::OneCall::DailyWeather.new(i, options) } if daily

--- a/lib/open_weather/version.rb
+++ b/lib/open_weather/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenWeather
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end

--- a/spec/fixtures/open_weather/one_call/base_plan.yml
+++ b/spec/fixtures/open_weather/one_call/base_plan.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.openweathermap.org/data/3.0/onecall/timemachine?appid=api-key&dt=1589173200&lat=33.441792&lon=-94.037689
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenWeather Ruby Client/0.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Date:
+      - Sat, 19 Oct 2024 11:55:35 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '387'
+      Connection:
+      - keep-alive
+      X-Cache-Key:
+      - "/data/3.0/onecall/timemachine?dt=1589173200&lat=33.44&lon=-94.04"
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: '{"lat":33.4418,"lon":-94.0377,"timezone":"America/Chicago","timezone_offset":-18000,"data":[{"dt":1589173200,"sunrise":1589195910,"sunset":1589245597,"temp":289.88,"feels_like":289.75,"pressure":1024,"humidity":82,"dew_point":286.79,"clouds":20,"visibility":10000,"wind_speed":0,"wind_deg":0,"wind_gust":0,"weather":[{"id":801,"main":"Clouds","description":"few
+        clouds","icon":"02n"}]}]}'
+  recorded_at: Sat, 19 Oct 2024 11:55:35 GMT
+recorded_with: VCR 6.2.0

--- a/spec/open_weather/one_call/one_call_spec.rb
+++ b/spec/open_weather/one_call/one_call_spec.rb
@@ -79,6 +79,21 @@ RSpec.describe 'one_call' do
     expect(data.daily).to be nil
   end
 
+  it 'base plan', vcr: { cassette_name: 'one_call/base_plan' } do
+    data = client.one_call(lat: 33.441792, lon: -94.037689, dt: Time.at(1589173200))
+    expect(data).to be_a OpenWeather::Models::OneCall::Weather
+    expect(data.lat).to eq 33.4418
+    expect(data.lon).to eq(-94.0377)
+    expect(data.timezone).to eq 'America/Chicago'
+    expect(data.data).to be_a Array
+    expect(data.data.size).to eq 1
+    expect(data.data.first).to be_a OpenWeather::Models::OneCall::CurrentWeather
+    expect(data.data.first.temp).to eq 289.88
+    expect(data.data.first.temp_c).to eq 16.73
+    expect(data.data.first.temp_k).to eq 289.88
+    expect(data.data.first.temp_f).to eq 62.11
+  end
+
   it 'raises an out of range error', vcr: { cassette_name: 'one_call/error_out_of_range' } do
     expect do
       client.one_call(


### PR DESCRIPTION
The `one_call` API seems to return `data` on the base plan instead of current, hourly, minutely, etc.
 
Closes https://github.com/dblock/open-weather-ruby-client/issues/44.